### PR TITLE
chore(ci): fix job dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,7 @@ jobs:
   release:
     name: Release
     runs-on: ${{ vars.RUNS_ON }}
+    needs: build
     env:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN_PRIVATE_READ }}
 


### PR DESCRIPTION
This PR adds the missing `needs: build` to the _Release_ job.