### PR TITLE
fix(tests): remove an unnecessary `withNavigation` guard

### DIFF
--- a/tests/playwright/specs/consumers/02-ConsumerCredentials.spec.ts
+++ b/tests/playwright/specs/consumers/02-ConsumerCredentials.spec.ts
@@ -49,7 +49,7 @@ test.describe('consumer credentials', () => {
   test('consumer show - can delete a credential', async ({ page }) => {
     await withNavigation(page, () => clickEntityListAction(page, 'view'))
     await switchDetailTab(page, 'credentials')
-    await withNavigation(page, () => clickEntityListAction(page, 'delete'))
+    await clickEntityListAction(page, 'delete')
     await expect(page.locator('.k-modal-dialog.modal-dialog')).toBeVisible()
     await page.locator('.k-prompt-action-buttons .danger').click()
     const basicAuthLocator = page.locator('.credential-list-wrapper').filter({ hasText: 'Basic Authentication' })


### PR DESCRIPTION
### Summary

Clicking "Delete" will not trigger navigate action and will cause flaky. Simply remove the `withNavigation` guard could fix this

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_