### PR TITLE
fix(sidebar): ui text 'route' -> 'routes'

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -37,9 +37,9 @@ const sidebarItems = computed<Array<SidebarPrimaryItem>>(() => [
     active: route.meta?.entity === 'service',
   },
   {
-    name: 'Route',
+    name: 'Routes',
     to: { name: 'route-list' },
-    key: 'Route',
+    key: 'Routes',
     active: route.meta?.entity === 'route',
   },
   {


### PR DESCRIPTION
### Summary

This fixes the UI text for `routes` on the sidebar: Route → Routes

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_