### PR TITLE
fix(*): title line height in 404 page

### DIFF
--- a/src/pages/NotFound.vue
+++ b/src/pages/NotFound.vue
@@ -26,6 +26,7 @@
   h2 {
     font-size: 72px;
     color: var(--black-45, rgba(0, 0, 0, .45));
+    line-height: 1;
   }
 
   p {


### PR DESCRIPTION
### Summary

<!--- Why is this change required? What problem does it solve? -->

Fix 404 page title height. This is caused by the latest `@kong-ui-public/app-layout`.

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_