### PR TITLE
fix(plugin): field names with dashes

### DIFF
--- a/src/pages/plugins/Form.vue
+++ b/src/pages/plugins/Form.vue
@@ -563,7 +563,18 @@ export default {
         schema = schema.reduce((acc, current) => {
           const key = Object.keys(current)[0]
 
-          acc[key] = current[key]
+          // If the backend schema has dashes in the field name (e.g. config.response_headers.X-Cache-Status of the proxy-cache plugin),
+          // replace them with underscores because the shared form component treats dashes as separators for nested fields
+          if (key.match(/-/g)) {
+            acc[key.replace(/-/g, '_')] = {
+              ...current[key],
+              // A flag to indicate the field name has dashes originally and they are replaced with underscores.
+              // When submitting the form, the underscores should be replaced with dashes again
+              fieldNameHasDashes: true,
+            }
+          } else {
+            acc[key] = current[key]
+          }
 
           return acc
         }, {})
@@ -736,6 +747,9 @@ export default {
         }
 
         output[field].valueType = valueType
+        if (scheme.fieldNameHasDashes) {
+          output[field].fieldNameHasDashes = true
+        }
       })
 
       return output


### PR DESCRIPTION
### Summary

<!--- Why is this change required? What problem does it solve? -->

Fixes a bug where the `proxy-cache` plugin cannot be successfully installed.

Cause: the schema of this plugin includes some fields whose names have dashes in them. Previously we only supported underscores in field names and dashes were treated as indicators for parent/child field.

This PR converts dashes to underscores before passing the schema to `@kong-ui-public/forms` and converts them back to dashes before submitting.

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_