### PR TITLE
fix(kconfig): remove kong version from kconfig.js

### DIFF
--- a/src/components/MakeAWish.vue
+++ b/src/components/MakeAWish.vue
@@ -16,12 +16,13 @@
 import { computed } from 'vue'
 import { useRoute } from 'vue-router'
 import { useI18n } from '@/composables/useI18n'
-import { config } from 'config'
+import { useInfoStore } from '@/stores/info'
 
 const route = useRoute()
 const { t } = useI18n()
+const infoStore = useInfoStore()
 
-const mailToUrl = computed(() => `mailto:wish@konghq.com?subject=${t('wish.subject', { title: `${route.meta.title} | Kong Manager OSS@${config.GATEWAY_VERSION}` })}`)
+const mailToUrl = computed(() => `mailto:wish@konghq.com?subject=${t('wish.subject', { title: `${route.meta.title} | Kong Manager OSS@${infoStore.kongVersion}` })}`)
 </script>
 
 <style scoped lang="scss">

--- a/src/composables/useDetailGeneralConfig.ts
+++ b/src/composables/useDetailGeneralConfig.ts
@@ -1,6 +1,9 @@
 import { reactive } from 'vue'
 import { config } from 'config'
+import { useInfoStore } from '@/stores/info'
 import type { KongManagerBaseEntityConfig } from '@kong-ui-public/entities-shared'
+
+const infoStore = useInfoStore()
 
 export const useDetailGeneralConfig = () => {
   return reactive({
@@ -8,7 +11,7 @@ export const useDetailGeneralConfig = () => {
     workspace: '',
     gatewayInfo: {
       edition: config.GATEWAY_EDITION,
-      version: config.GATEWAY_VERSION,
+      version: infoStore.kongVersion,
     },
     apiBaseUrl: config.ADMIN_API_URL,
     jsonYamlEnabled: true,

--- a/src/composables/useDocsLink.ts
+++ b/src/composables/useDocsLink.ts
@@ -1,18 +1,23 @@
 import { formatVersion } from '@/utils'
 import { config, type GatewayEdition } from 'config'
 import { EntityType } from '@/types'
+import { computed } from 'vue'
+import { useInfoStore } from '@/stores/info'
+
+const infoStore = useInfoStore()
+const kongVersion = computed(() => infoStore.kongVersion)
 
 const getVersionInPath = (edition: GatewayEdition) => {
-  if (!config.GATEWAY_VERSION) {
+  if (!kongVersion.value) {
     return 'latest'
   }
 
   return edition === 'enterprise'
     // For Enterprise, the version has a pattern of <major>.<minor>.0.x where the 3rd digit
     // will always be 0 regardless of the actual patch version
-    ? `${formatVersion(config.GATEWAY_VERSION)}.0.x`
+    ? `${formatVersion(kongVersion.value)}.0.x`
     // For OSS, the version has a pattern of <major>.<minor>.x
-    : `${formatVersion(config.GATEWAY_VERSION)}.x`
+    : `${formatVersion(kongVersion.value)}.x`
 }
 
 export const useDocsLink = (entityType: EntityType) => {

--- a/src/composables/useFormGeneralConfig.ts
+++ b/src/composables/useFormGeneralConfig.ts
@@ -1,6 +1,9 @@
 import { reactive } from 'vue'
 import { config } from 'config'
+import { useInfoStore } from '@/stores/info'
 import type { KongManagerBaseFormConfig } from '@kong-ui-public/entities-shared'
+
+const infoStore = useInfoStore()
 
 export const useFormGeneralConfig = () => {
   return reactive({
@@ -8,7 +11,7 @@ export const useFormGeneralConfig = () => {
     workspace: '',
     gatewayInfo: {
       edition: config.GATEWAY_EDITION,
-      version: config.GATEWAY_VERSION,
+      version: infoStore.kongVersion,
     },
     apiBaseUrl: config.ADMIN_API_URL,
   } as Pick<KongManagerBaseFormConfig, 'app' | 'workspace' | 'gatewayInfo' | 'apiBaseUrl'>)

--- a/src/composables/useGatewayFeatureSupported.ts
+++ b/src/composables/useGatewayFeatureSupported.ts
@@ -1,13 +1,18 @@
+import { computed } from 'vue'
+import { useInfoStore } from '@/stores/info'
 import { useGatewayFeatureSupported as sharedComposable } from '@kong-ui-public/entities-shared'
 import { config } from 'config'
 
 type Arguments = Parameters<typeof sharedComposable>[0]
 
+const infoStore = useInfoStore()
+const kongVersion = computed(() => infoStore.kongVersion)
+
 export const useGatewayFeatureSupported = (supportedRange: Arguments['supportedRange']) => {
   return sharedComposable({
     gatewayInfo: {
       edition: config.GATEWAY_EDITION ?? 'community',
-      version: config.GATEWAY_VERSION ?? '',
+      version: kongVersion.value ?? '',
     },
     supportedRange,
   })

--- a/src/composables/useListGeneralConfig.ts
+++ b/src/composables/useListGeneralConfig.ts
@@ -1,6 +1,9 @@
 import { reactive } from 'vue'
 import { config } from 'config'
+import { useInfoStore } from '@/stores/info'
 import type { KongManagerBaseTableConfig } from '@kong-ui-public/entities-shared'
+
+const infoStore = useInfoStore()
 
 export const useListGeneralConfig = () => {
   return reactive({
@@ -8,7 +11,7 @@ export const useListGeneralConfig = () => {
     workspace: '',
     gatewayInfo: {
       edition: config.GATEWAY_EDITION,
-      version: config.GATEWAY_VERSION,
+      version: infoStore.kongVersion,
     },
     apiBaseUrl: config.ADMIN_API_URL,
     // Kong Gateway OSS only supports exact match and does not support sorting

--- a/src/config.ts
+++ b/src/config.ts
@@ -52,12 +52,8 @@ export const config = {
     return `${window.location.protocol}//${window.location.hostname}:${port}`
   },
 
-  get GATEWAY_VERSION () {
-    return getConfig<string | null>('KONG_VERSION', null)
-  },
-
   get GATEWAY_EDITION () {
-    return getConfig<GatewayEdition | null>('KONG_EDITION', null)
+    return getConfig<GatewayEdition | null>('KONG_EDITION', 'community')
   },
 
   get ANONYMOUS_REPORTS () {

--- a/src/pages/overview/Overview.vue
+++ b/src/pages/overview/Overview.vue
@@ -76,9 +76,10 @@ const infoStore = useInfoStore()
 
 const config = computed(() => ({
   ...infoStore.infoConfig,
+  kongVersion: infoStore.kongVersion,
   hostname: infoStore.info.hostname,
 }))
-const version = computed(() => gatewayConfig.GATEWAY_VERSION ? `${formatVersion(gatewayConfig.GATEWAY_VERSION)}.x` : 'latest')
+const version = computed(() => config.value.kongVersion ? `${formatVersion(config.value.kongVersion)}.x` : 'latest')
 const info = computed(() => {
   const guiListeners = config.value.admin_gui_listeners
   const nonSslGuiListener = guiListeners?.find?.(listener => !listener.ssl)
@@ -97,7 +98,7 @@ const info = computed(() => {
         },
         {
           label: t('overview.info.gateway.version'),
-          value: gatewayConfig.GATEWAY_VERSION,
+          value: config.value.kongVersion,
         },
       ],
     },


### PR DESCRIPTION
### Summary
1. Remove the Kong version from `kconfig.js`
2. Retrieve the Kong version from `useInfoStore`.
<!--- Why is this change required? What problem does it solve? -->

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
FTI-5557