### PR TITLE
fix: temporary skip ee tests

### DIFF
--- a/tests/playwright/specs-ee/plugins/01-Plugins.spec.ts
+++ b/tests/playwright/specs-ee/plugins/01-Plugins.spec.ts
@@ -4,7 +4,7 @@ import baseTest from '@pw/base-test'
 const test = baseTest()
 
 test.describe('PLACEHOLDER', () => {
-  test('is enterprise edition', async ({ page }) => {
+  test.skip('is enterprise edition', async ({ page }) => {
     await page.goto('/')
     await expect(page.locator('[aria-label="Gateway"] .info-list')).toContainText('enterprise')
   })


### PR DESCRIPTION
the gateway edition detection was not functional due to https://github.com/Kong/kong-ee/pull/7290, we have to disable the ee-related tests until https://github.com/Kong/kong/pull/12097 get merged.

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_