### PR TITLE
chore(eslint): always require vue extension in import statement

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -20,7 +20,18 @@ module.exports = {
   plugins: [
     '@typescript-eslint',
     'vuejs-accessibility',
+    'import',
   ],
+  settings: {
+    'import/resolver': {
+      alias: {
+        map: [
+          ['@', './src'],
+        ],
+        extensions: ['.js', '.ts', '.vue'],
+      },
+    },
+  },
   // add your custom rules here
   rules: {
     // allow paren-less arrow functions
@@ -53,6 +64,7 @@ module.exports = {
     'indent': ['error', 2, { offsetTernaryExpressions: true, SwitchCase: 1 }],
     // disable this rule since it may conflict with 'export default' in vue single file component
     'import/first': 'off',
+    'import/extensions': ['error', 'ignorePackages', { ts: 'never', js: 'never', vue: 'always' }],
     // disable this rule since it may conflict with some unit tests
     'prefer-promise-reject-errors': 'off',
     // trailing comma is beneficial for git diff
@@ -94,6 +106,7 @@ module.exports = {
     'func-call-spacing': 'off',
     '@typescript-eslint/func-call-spacing': 'error',
 
+    // vue
     'vue/no-deprecated-dollar-listeners-api': 'error',
     'vue/no-deprecated-events-api': 'error',
     'vue/no-deprecated-v-on-native-modifier': 'error',

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "dotenv": "^16.0.1",
     "eslint": "^8.54.0",
     "eslint-config-standard": "^17.1.0",
+    "eslint-import-resolver-alias": "^1.1.2",
     "eslint-plugin-import": "^2.29.0",
     "eslint-plugin-n": "^16.3.1",
     "eslint-plugin-playwright": "^0.18.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1926,6 +1926,11 @@ eslint-config-standard@^17.1.0:
   resolved "https://registry.yarnpkg.com/eslint-config-standard/-/eslint-config-standard-17.1.0.tgz#40ffb8595d47a6b242e07cbfd49dc211ed128975"
   integrity sha512-IwHwmaBNtDK4zDHQukFDW5u/aTb8+meQWZvNFWkiGmbWjD6bqyuSSBxxXKkCftCUzc1zwCH2m/baCNDLGmuO5Q==
 
+eslint-import-resolver-alias@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/eslint-import-resolver-alias/-/eslint-import-resolver-alias-1.1.2.tgz#297062890e31e4d6651eb5eba9534e1f6e68fc97"
+  integrity sha512-WdviM1Eu834zsfjHtcGHtGfcu+F30Od3V7I9Fi57uhBEwPkjDcii7/yW8jAT+gOhn4P/vOxxNAXbFAKsrrc15w==
+
 eslint-import-resolver-node@^0.3.9:
   version "0.3.9"
   resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz#d4eaac52b8a2e7c3cd1903eb00f7e053356118ac"


### PR DESCRIPTION
import vue sfc with `.vue` extension can help vscode resolving imports

adopted from kong/kong-admin#3014

### Summary

<!--- Why is this change required? What problem does it solve? -->

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_