### PR TITLE
chore(*): update dependabot rules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,6 +32,9 @@ updates:
     allow:
       - dependency-name: "@kong/*"
       - dependency-name: "@kong-ui-public/*"
+      - dependency-name: "@playwright/test"
+    ignore:
+      - dependency-name: "@kong/kongponents"
     groups:
       kong-packages:
         patterns:


### PR DESCRIPTION
### Summary

<!--- Why is this change required? What problem does it solve? -->

- Temporarily disables version upgrades for `@kong/kongponents` as its alpha versions will introduce breaking changes.
- Adds rule for `@playwright/test` in the root directory so its version will stay the same as the one in the `tests/playwright` directory.

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_