### PR TITLE
chore(*): remove outdated event handlers

### DIFF
--- a/src/pages/ca-certificates/Detail.vue
+++ b/src/pages/ca-certificates/Detail.vue
@@ -9,12 +9,10 @@
   <CACertificateConfigCard
     :config="caCertificateDetailConfig"
     @fetch:success="onFetchSuccess"
-    @copy:success="onCopySuccess"
   />
 </template>
 
 <script setup lang="ts">
-import { useCopyEventHandlers } from '@/composables/useCopyEventHandlers'
 import { useDetailGeneralConfig } from '@/composables/useDetailGeneralConfig'
 import { useI18n } from '@/composables/useI18n'
 import { CACertificateConfigCard } from '@kong-ui-public/entities-certificates'
@@ -36,14 +34,6 @@ const caCertificateDetailConfig = reactive({
   ...useDetailGeneralConfig(),
   entityId: id.value,
 })
-
-const { onCopySuccess: openToaster } = useCopyEventHandlers()
-
-const onCopySuccess = () => {
-  openToaster({
-    message: t('global.copied'),
-  })
-}
 
 const onFetchSuccess = (entity) => {
   titleId.value = entity.id

--- a/src/pages/certificates/Detail.vue
+++ b/src/pages/certificates/Detail.vue
@@ -9,12 +9,10 @@
   <CertificateConfigCard
     :config="certificateDetailConfig"
     @fetch:success="onFetchSuccess"
-    @copy:success="onCopySuccess"
   />
 </template>
 
 <script setup lang="ts">
-import { useCopyEventHandlers } from '@/composables/useCopyEventHandlers'
 import { useDetailGeneralConfig } from '@/composables/useDetailGeneralConfig'
 import { useI18n } from '@/composables/useI18n'
 import { CertificateConfigCard } from '@kong-ui-public/entities-certificates'
@@ -36,14 +34,6 @@ const certificateDetailConfig = reactive({
   ...useDetailGeneralConfig(),
   entityId: id.value,
 })
-
-const { onCopySuccess: openToaster } = useCopyEventHandlers()
-
-const onCopySuccess = () => {
-  openToaster({
-    message: t('global.copied'),
-  })
-}
 
 const onFetchSuccess = (entity) => {
   titleId.value = entity.id

--- a/src/pages/consumers/Detail.vue
+++ b/src/pages/consumers/Detail.vue
@@ -15,7 +15,6 @@
       <ConsumerConfigCard
         :config="consumerDetailConfig"
         @fetch:success="onFetchSuccess"
-        @copy:success="onCopySuccess"
       />
     </template>
     <template #credentials>
@@ -32,7 +31,6 @@ import { computed, reactive, ref, onMounted } from 'vue'
 import { useRoute } from 'vue-router'
 import { ConsumerConfigCard } from '@kong-ui-public/entities-consumers'
 import { useDetailGeneralConfig } from '@/composables/useDetailGeneralConfig'
-import { useCopyEventHandlers } from '@/composables/useCopyEventHandlers'
 import { useI18n } from '@/composables/useI18n'
 import { useTabs } from '@/composables/useTabs'
 import { apiService } from '@/services/apiService'
@@ -67,14 +65,6 @@ const consumerDetailConfig = reactive({
   ...useDetailGeneralConfig(),
   entityId: id.value,
 })
-
-const { onCopySuccess: openToaster } = useCopyEventHandlers()
-
-const onCopySuccess = () => {
-  openToaster({
-    message: t('global.copied'),
-  })
-}
 
 const onFetchSuccess = (entity) => {
   titleName.value = entity.username ?? entity.custom_id

--- a/src/pages/key-sets/Detail.vue
+++ b/src/pages/key-sets/Detail.vue
@@ -15,7 +15,6 @@
       <KeySetConfigCard
         :config="keySetDetailConfig"
         @fetch:success="onFetchSuccess"
-        @copy:success="onCopySuccess"
       />
     </template>
     <template #keys>
@@ -29,7 +28,6 @@ import { computed, reactive, ref, onMounted } from 'vue'
 import { useRoute } from 'vue-router'
 import { KeySetConfigCard } from '@kong-ui-public/entities-key-sets'
 import { useDetailGeneralConfig } from '@/composables/useDetailGeneralConfig'
-import { useCopyEventHandlers } from '@/composables/useCopyEventHandlers'
 import { useI18n } from '@/composables/useI18n'
 import { useTabs } from '@/composables/useTabs'
 import { apiService } from '@/services/apiService'
@@ -59,14 +57,6 @@ const keySetDetailConfig = reactive({
   ...useDetailGeneralConfig(),
   entityId: id.value,
 })
-
-const { onCopySuccess: openToaster } = useCopyEventHandlers()
-
-const onCopySuccess = () => {
-  openToaster({
-    message: t('global.copied'),
-  })
-}
 
 const onFetchSuccess = (entity) => {
   titleName.value = entity.name ?? entity.id

--- a/src/pages/keys/Detail.vue
+++ b/src/pages/keys/Detail.vue
@@ -10,7 +10,6 @@
     :config="keyDetailConfig"
     :key-set-id="keySetId"
     @fetch:success="onFetchSuccess"
-    @copy:success="onCopySuccess"
     @navigation-click="onNavigationClick"
   />
 </template>
@@ -20,7 +19,6 @@ import { computed, reactive, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { KeyConfigCard } from '@kong-ui-public/entities-keys'
 import { useDetailGeneralConfig } from '@/composables/useDetailGeneralConfig'
-import { useCopyEventHandlers } from '@/composables/useCopyEventHandlers'
 import { useI18n } from '@/composables/useI18n'
 
 defineOptions({
@@ -40,14 +38,6 @@ const keyDetailConfig = reactive({
   ...useDetailGeneralConfig(),
   entityId: id.value,
 })
-
-const { onCopySuccess: openToaster } = useCopyEventHandlers()
-
-const onCopySuccess = () => {
-  openToaster({
-    message: t('global.copied'),
-  })
-}
 
 const onNavigationClick = (id: string) => {
   router.push({

--- a/src/pages/plugins/Detail.vue
+++ b/src/pages/plugins/Detail.vue
@@ -24,7 +24,6 @@
     :config="pluginDetailConfig"
     :scoped-entity-type="entityScope?.typeLiteral"
     :scoped-entity-id="entityScope?.id"
-    @copy:success="onCopySuccess"
   />
 </template>
 
@@ -33,8 +32,6 @@ import { computed, reactive } from 'vue'
 import { useRoute } from 'vue-router'
 import { PluginConfigCard, PluginIcon } from '@kong-ui-public/entities-plugins'
 import { useDetailGeneralConfig } from '@/composables/useDetailGeneralConfig'
-import { useCopyEventHandlers } from '@/composables/useCopyEventHandlers'
-import { useI18n } from '@/composables/useI18n'
 import { pluginMeta } from '@/pages/plugins/PluginMeta'
 
 defineOptions({
@@ -42,7 +39,6 @@ defineOptions({
 })
 
 const route = useRoute()
-const { t } = useI18n()
 
 const id = computed(() => (route.params.id as string) ?? '')
 const pluginType = computed(() => (route.params.pluginType ?? '') as string)
@@ -75,14 +71,6 @@ const pluginDetailConfig = reactive({
   entityId: id.value,
   pluginType: pluginType.value,
 })
-
-const { onCopySuccess: openToaster } = useCopyEventHandlers()
-
-const onCopySuccess = () => {
-  openToaster({
-    message: t('global.copied'),
-  })
-}
 </script>
 
 <style scoped lang="scss">

--- a/src/pages/routes/Detail.vue
+++ b/src/pages/routes/Detail.vue
@@ -18,7 +18,6 @@
         :service-id="serviceId"
         @navigation-click="onNavigationClick"
         @fetch:success="onFetchSuccess"
-        @copy:success="onCopySuccess"
       />
     </template>
     <template #plugins>
@@ -32,7 +31,6 @@ import { computed, reactive, ref, onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { RouteConfigCard } from '@kong-ui-public/entities-routes'
 import { useDetailGeneralConfig } from '@/composables/useDetailGeneralConfig'
-import { useCopyEventHandlers } from '@/composables/useCopyEventHandlers'
 import { useI18n } from '@/composables/useI18n'
 import { useTabs } from '@/composables/useTabs'
 import { useListRedirect } from '@/composables/useListRedirect'
@@ -67,14 +65,6 @@ const routeDetailConfig = reactive({
   ...useDetailGeneralConfig(),
   entityId: id.value,
 })
-
-const { onCopySuccess: openToaster } = useCopyEventHandlers()
-
-const onCopySuccess = () => {
-  openToaster({
-    message: t('global.copied'),
-  })
-}
 
 const onFetchSuccess = (entity) => {
   titleName.value = entity.name ?? entity.id

--- a/src/pages/services/Detail.vue
+++ b/src/pages/services/Detail.vue
@@ -15,7 +15,6 @@
       <GatewayServiceConfigCard
         :config="serviceDetailConfig"
         @fetch:success="onFetchSuccess"
-        @copy:success="onCopySuccess"
       />
     </template>
     <template #routes>
@@ -32,7 +31,6 @@ import { computed, reactive, ref, onMounted } from 'vue'
 import { useRoute } from 'vue-router'
 import { GatewayServiceConfigCard } from '@kong-ui-public/entities-gateway-services'
 import { useDetailGeneralConfig } from '@/composables/useDetailGeneralConfig'
-import { useCopyEventHandlers } from '@/composables/useCopyEventHandlers'
 import { useI18n } from '@/composables/useI18n'
 import { useTabs } from '@/composables/useTabs'
 import { apiService } from '@/services/apiService'
@@ -67,14 +65,6 @@ const serviceDetailConfig = reactive({
   ...useDetailGeneralConfig(),
   entityId: id.value,
 })
-
-const { onCopySuccess: openToaster } = useCopyEventHandlers()
-
-const onCopySuccess = () => {
-  openToaster({
-    message: t('global.copied'),
-  })
-}
 
 const onFetchSuccess = (entity) => {
   titleName.value = entity.name ?? entity.id

--- a/src/pages/upstreams/Detail.vue
+++ b/src/pages/upstreams/Detail.vue
@@ -15,7 +15,6 @@
       <UpstreamsConfigCard
         :config="upstreamDetailConfig"
         @fetch:success="onFetchSuccess"
-        @copy:success="onCopySuccess"
       />
     </template>
     <template #targets>
@@ -29,7 +28,6 @@ import { computed, reactive, ref } from 'vue'
 import { useRoute } from 'vue-router'
 import { UpstreamsConfigCard } from '@kong-ui-public/entities-upstreams-targets'
 import { useDetailGeneralConfig } from '@/composables/useDetailGeneralConfig'
-import { useCopyEventHandlers } from '@/composables/useCopyEventHandlers'
 import { useI18n } from '@/composables/useI18n'
 import { useTabs } from '@/composables/useTabs'
 
@@ -59,14 +57,6 @@ const upstreamDetailConfig = reactive({
   ...useDetailGeneralConfig(),
   entityId: id.value,
 })
-
-const { onCopySuccess: openToaster } = useCopyEventHandlers()
-
-const onCopySuccess = () => {
-  openToaster({
-    message: t('global.copied'),
-  })
-}
 
 const onFetchSuccess = (entity) => {
   titleName.value = entity.name ?? entity.id

--- a/src/pages/vaults/Detail.vue
+++ b/src/pages/vaults/Detail.vue
@@ -9,7 +9,6 @@
   <VaultConfigCard
     :config="vaultDetailConfig"
     @fetch:success="onFetchSuccess"
-    @copy:success="onCopySuccess"
   />
 </template>
 
@@ -18,7 +17,6 @@ import { computed, reactive, ref } from 'vue'
 import { useRoute } from 'vue-router'
 import { VaultConfigCard } from '@kong-ui-public/entities-vaults'
 import { useDetailGeneralConfig } from '@/composables/useDetailGeneralConfig'
-import { useCopyEventHandlers } from '@/composables/useCopyEventHandlers'
 import { useI18n } from '@/composables/useI18n'
 
 defineOptions({
@@ -36,14 +34,6 @@ const vaultDetailConfig = reactive({
   ...useDetailGeneralConfig(),
   entityId: id.value,
 })
-
-const { onCopySuccess: openToaster } = useCopyEventHandlers()
-
-const onCopySuccess = () => {
-  openToaster({
-    message: t('global.copied'),
-  })
-}
 
 const onFetchSuccess = (entity) => {
   titleName.value = entity.name ?? entity.id


### PR DESCRIPTION
### Summary

<!--- Why is this change required? What problem does it solve? -->

Entity config cards no longer emit `copy:success` and `copy:error` events.

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_