### PR TITLE
feat(routes): support expressions routes [KM-20]

### DIFF
--- a/.ci/docker-compose.yml
+++ b/.ci/docker-compose.yml
@@ -50,6 +50,7 @@ services:
       KONG_PG_USER: kong
       KONG_ADMIN_LISTEN: "0.0.0.0:8001"
       KONG_ANONYMOUS_REPORTS: "off"
+      KONG_ROUTER_FLAVOR:
     restart: always
     depends_on:
       &kong-depends_on

--- a/.github/actions/select-gateway-image/action.yml
+++ b/.github/actions/select-gateway-image/action.yml
@@ -20,7 +20,7 @@ runs:
       shell: bash
       env:
         DEFAULT_GATEWAY_IMAGE: |-
-          ${{ format('{0}', inputs.enterprise) == 'true' && 'kong/kong-gateway-internal:nightly-ubuntu' || 'kong/kong:nightly-ubuntu' }}
+          ${{ format('{0}', inputs.enterprise) == 'true' && 'kong/kong-gateway-internal:nightly-ubuntu' || 'kong/kong:master-ubuntu' }}
       run: |
         GATEWAY_IMAGE="${{ inputs.current-image }}"
 

--- a/.github/workflows/.reusable_e2e_tests_oss.yml
+++ b/.github/workflows/.reusable_e2e_tests_oss.yml
@@ -34,6 +34,10 @@ jobs:
           - services
           - snis
           - upstreams
+        router-flavor: [traditional_compatible]
+        include:
+          - suite: routes-expressions
+            router-flavor: expressions
       fail-fast: false
     name: ${{ matrix.suite }}
     runs-on: ${{ vars.RUNS_ON }}
@@ -84,6 +88,7 @@ jobs:
         working-directory: ${{ github.workspace }}
         env:
           GATEWAY_IMAGE: ${{ inputs.gateway-image }}
+          KONG_ROUTER_FLAVOR: ${{ matrix.router-flavor }}
         run: |
           _compose_exit=0
           docker compose -f .ci/docker-compose.yml up -d kong --wait || _compose_exit=$?

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "@kong-ui-public/entities-key-sets": "^3.0.11",
     "@kong-ui-public/entities-keys": "^3.0.11",
     "@kong-ui-public/entities-plugins": "^4.1.0",
-    "@kong-ui-public/entities-routes": "^3.0.0",
-    "@kong-ui-public/entities-shared": "^3.0.0",
+    "@kong-ui-public/entities-routes": "^3.1.5",
+    "@kong-ui-public/entities-shared": "^3.1.1",
     "@kong-ui-public/entities-snis": "^3.0.11",
     "@kong-ui-public/entities-upstreams-targets": "^3.0.11",
     "@kong-ui-public/entities-vaults": "^3.0.11",
@@ -84,6 +84,7 @@
     "typescript": "^5.3.2",
     "vite": "^4.3.9",
     "vite-plugin-html": "^3.2.0",
+    "vite-plugin-monaco-editor": "^1.1.0",
     "vue-eslint-parser": "^9.3.2",
     "vue-tsc": "^1.8.22"
   }

--- a/src/pages/routes/Form.vue
+++ b/src/pages/routes/Form.vue
@@ -4,6 +4,7 @@
     :config="routeFormConfig"
     :route-id="id"
     :service-id="serviceId"
+    :route-flavors="routeFlavors"
     @update="handleUpdate"
   />
 </template>
@@ -11,11 +12,13 @@
 <script setup lang="ts">
 import { computed, reactive } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
-import { RouteForm } from '@kong-ui-public/entities-routes'
+import { RouteForm, type RouteFlavors } from '@kong-ui-public/entities-routes'
 import { useFormGeneralConfig } from '@/composables/useFormGeneralConfig'
 import { useFormRedirectOnCancel, useFormRedirectOnUpdate } from '@/composables/useFormRedirect'
 import { useToaster } from '@/composables/useToaster'
 import { useI18n } from '@/composables/useI18n'
+import { useInfoStore } from '@/stores/info'
+import { storeToRefs } from 'pinia'
 
 defineOptions({
   name: 'RouteForm',
@@ -25,6 +28,12 @@ const route = useRoute()
 const router = useRouter()
 const toaster = useToaster()
 const { t } = useI18n()
+
+const infoStore = useInfoStore()
+const { infoConfig } = storeToRefs(infoStore)
+const routeFlavors = computed<RouteFlavors>(() => ({
+  traditional: true, expressions: infoConfig.value.router_flavor === 'expressions',
+}))
 
 const id = computed(() => (route.params.id as string) ?? '')
 const serviceId = computed(() => (route.query.serviceId as string) ?? '')

--- a/src/pages/routes/List.vue
+++ b/src/pages/routes/List.vue
@@ -19,6 +19,7 @@
     :can-delete="canDelete"
     :can-edit="canEdit"
     :can-retrieve="canRetrieve"
+    :has-expression-column="supportExpressions"
     @copy:success="onCopySuccess"
     @copy:error="onCopyError"
     @delete:success="onDeleteSuccess"
@@ -37,6 +38,8 @@ import { useToaster } from '@/composables/useToaster'
 import { useI18n } from '@/composables/useI18n'
 import { useDocsLink } from '@/composables/useDocsLink'
 import { EntityType } from '@/types'
+import { useInfoStore } from '@/stores/info'
+import { storeToRefs } from 'pinia'
 
 defineOptions({ name: 'RouteList' })
 
@@ -45,6 +48,10 @@ const route = useRoute()
 const { t } = useI18n()
 const docsLink = useDocsLink(EntityType.Route)
 const { createRedirectRouteQuery } = useListRedirect()
+
+const infoStore = useInfoStore()
+const { infoConfig } = storeToRefs(infoStore)
+const supportExpressions = computed(() => infoConfig.value.router_flavor === 'expressions')
 
 const serviceId = computed(() => (route.params?.id ?? '') as string)
 const cacheIdentifier = computed(() => `routes-${serviceId.value}`)

--- a/tests/playwright/commands/fetchKongResource.ts
+++ b/tests/playwright/commands/fetchKongResource.ts
@@ -1,0 +1,21 @@
+import { handleRequestError } from '@pw/helpers/misc'
+import type { AxiosError, AxiosRequestConfig, Method } from 'axios'
+import axios from 'axios'
+
+export const fetchKongResource = async (endpoint: string) => {
+  const kongUrl = process.env.KM_TEST_API_URL
+  const options: AxiosRequestConfig = {
+    method: 'GET' as Method,
+    url: `${kongUrl}${endpoint}`,
+    headers: {
+      'Content-Type': 'application/json',
+      'Connection': 'close',
+    },
+  }
+
+  try {
+    return await axios(options)
+  } catch (err) {
+    handleRequestError('fetchKongResource', err as AxiosError<object>)
+  }
+}

--- a/tests/playwright/pages/routes.ts
+++ b/tests/playwright/pages/routes.ts
@@ -10,3 +10,15 @@ export class RouteListPage extends POM {
     super(page, '/routes')
   }
 }
+
+export class RouteCreatePage extends POM {
+  public $ = {
+    ...POM.$,
+  }
+
+  constructor (page: Page, options: { serviceId?: string } = {}) {
+    const { serviceId = '' } = options
+
+    super(page, `/routes/create?serviceId=${serviceId}`)
+  }
+}

--- a/tests/playwright/specs/routes-expressions/01-Routes.spec.ts
+++ b/tests/playwright/specs/routes-expressions/01-Routes.spec.ts
@@ -1,0 +1,278 @@
+import { expect } from '@playwright/test'
+import baseTest from '@pw/base-test'
+import { clearKongResources } from '@pw/commands/clearKongResources'
+import { fetchKongResource } from '@pw/commands/fetchKongResource'
+import { RouteCreatePage } from '@pw/pages/routes'
+
+const test = baseTest().extend<{
+  routeCreatePage: RouteCreatePage
+}>({
+  routeCreatePage: async ({ page }, use) => use(new RouteCreatePage(page)),
+})
+
+test.describe('route creation page', () => {
+  // We assume that Gateway used to run this test group against has router_flavor = expressions
+  // Otherwise, we will make it fail here ...
+  test.beforeAll(async () => {
+    const kongInfoRes = await fetchKongResource('')
+
+    expect(
+      kongInfoRes?.data?.configuration?.router_flavor,
+      'this test group should only be performed against Gateway with router_flavor = expressions'
+    ).toEqual('expressions')
+
+    await clearKongResources('/routes')
+  })
+
+  test.beforeEach(async ({ routeCreatePage }) => {
+    await routeCreatePage.goto()
+  })
+
+  test.afterAll(async () => {
+    await clearKongResources('/routes')
+  })
+
+  test('tabs', async ({ page }) => {
+    await page.getByTestId('form-content').isVisible()
+
+    // tabs should be visible
+    await expect(page.getByTestId('route-form-config-tabs')).toBeVisible()
+    await expect(page.locator('#traditional-tab')).toBeVisible()
+    await expect(page.locator('#expressions-tab')).toBeVisible()
+  })
+
+  test('submit button states', async ({ page }) => {
+    await page.getByTestId('form-content').isVisible()
+
+    // traditional tab should be active by default
+    await expect(page.locator('#traditional-tab')).toHaveClass(/active/)
+    // submit button should be disabled
+    await expect(page.getByTestId('form-submit')).toBeDisabled()
+    // fill in a path
+    await page.getByTestId('route-form-paths-input-1').fill('/trad/1')
+    // submit button should be enabled
+    await expect(page.getByTestId('form-submit')).toBeEnabled()
+
+    // switch to the expressions tab
+    await page.locator('#expressions-tab').click()
+    // submit button should be disabled again
+    await expect(page.getByTestId('form-submit')).toBeDisabled()
+
+    // switch back to the traditional tab
+    await page.locator('#traditional-tab').click()
+    // submit button should be enabled again
+    await expect(page.getByTestId('form-submit')).toBeEnabled()
+
+    // switch back to the expressions tab
+    await page.locator('#expressions-tab').click()
+    // submit button should be disabled again
+    await expect(page.getByTestId('form-submit')).toBeDisabled()
+
+    // the editor shows invalid because it is empty
+    await expect(page.locator('.expression-editor')).toHaveClass(/invalid/)
+
+    const editor = page.locator('.monaco-editor').first()
+
+    // type a valid expression
+    await editor.click()
+    await page.keyboard.type('http.path == "/kong"')
+    // the editor should be no longer invalid
+    await expect(page.locator('.expression-editor')).not.toHaveClass(/invalid/)
+    // and the submit button should be enabled
+    await expect(page.getByTestId('form-submit')).toBeEnabled()
+
+    // delete the last character
+    await page.keyboard.press('Backspace')
+    // the editor should be invalid again
+    await expect(page.locator('.expression-editor')).toHaveClass(/invalid/)
+    // but the submit button is still enabled because we let the server handle uncaught errors
+    await expect(page.getByTestId('form-submit')).toBeEnabled()
+  })
+
+  test('view configuration', async ({ page }) => {
+    await page.getByTestId('form-content').isVisible()
+
+    // open the slide out
+    await page.getByTestId('form-view-configuration').click()
+    const slideOutTabs = page.getByTestId('form-view-configuration-slideout-tabs')
+    const configBlock = slideOutTabs.getByTestId('k-code-block').locator('code')
+
+    await expect(slideOutTabs).toBeVisible()
+    // should not contain the expression field
+    await expect(configBlock).not.toContainText(/expression:/)
+
+    // fill in a path
+    await page.getByTestId('route-form-paths-input-1').fill('/trad/1')
+    // should contain the paths field
+    await expect(configBlock).toContainText(/paths:/)
+    // still should not contain the expression field
+    await expect(configBlock).not.toContainText(/expression:/)
+
+    // switch to the expressions tab
+    await page.locator('#expressions-tab').click()
+    // should not contain the paths field
+    await expect(configBlock).not.toContainText(/paths:/)
+
+    const editor = page.locator('.monaco-editor').first()
+
+    // type a valid expression
+    await editor.click()
+    await page.keyboard.type('http.path == "/kong"')
+
+    // still should not contain the paths field
+    await expect(configBlock).not.toContainText(/paths:/)
+    // but should contain the expression field
+    await expect(configBlock).toContainText(/expression: http\.path == "\/kong"/)
+
+    // switch back to the traditional tab
+    await page.locator('#traditional-tab').click()
+    // should contain the paths field
+    await expect(configBlock).toContainText(/paths:/)
+    await expect(configBlock).toContainText(/- \/trad\/1/)
+    // should not contain the expression field
+    await expect(configBlock).not.toContainText(/expression:/)
+
+    // switch back to the expressions tab
+    await page.locator('#expressions-tab').click()
+    // should not contain the paths field
+    await expect(configBlock).not.toContainText(/paths:/)
+    // should contain the expression field
+    await expect(configBlock).toContainText(/expression: http\.path == "\/kong"/)
+  })
+
+  test('create a traditional route', async ({ page }) => {
+    await page.getByTestId('form-content').isVisible()
+
+    await page.getByTestId('route-form-name').fill('trad-1')
+    await page.getByTestId('route-form-paths-input-1').fill('/trad/1')
+    const submit = page.getByTestId('form-submit')
+
+    await expect(submit).toBeEnabled()
+    await submit.click()
+
+    await page.locator('.kong-ui-entities-routes-list').isVisible()
+    const trad1 = page.locator('.kong-ui-entities-routes-list table tr[data-testid="trad-1"]')
+
+    await trad1.isVisible()
+    await expect(trad1.getByTestId('paths')).toContainText('/trad/1')
+  })
+
+  test('create an expressions route', async ({ page }) => {
+    await page.getByTestId('form-content').isVisible()
+
+    await page.getByTestId('route-form-name').fill('expr-1')
+
+    // switch to the expressions tab
+    await page.locator('#expressions-tab').click()
+
+    const editor = page.locator('.monaco-editor').first()
+
+    // type a valid expression
+    await editor.click()
+    await page.keyboard.type('http.path == "/expr/1"')
+
+    const submit = page.getByTestId('form-submit')
+
+    await expect(submit).toBeEnabled()
+    await submit.click()
+
+    await page.locator('.kong-ui-entities-routes-list').isVisible()
+    const expr1 = page.locator('.kong-ui-entities-routes-list table tr[data-testid="expr-1"]')
+
+    await expr1.isVisible()
+    await expect(expr1.getByTestId('expression')).toContainText('http.path == "/expr/1"')
+  })
+
+  test('create a traditional route - also entered expressions', async ({ page }) => {
+    await page.getByTestId('form-content').isVisible()
+
+    await page.getByTestId('route-form-name').fill('trad-2')
+    await page.getByTestId('route-form-paths-input-1').fill('/trad/2')
+
+    // switch to the expressions tab
+    await page.locator('#expressions-tab').click()
+
+    const editor = page.locator('.monaco-editor').first()
+
+    // type a valid expression
+    await editor.click()
+    await page.keyboard.type('http.path == "/trad/2"')
+
+    // switch back to the traditional tab
+    await page.locator('#traditional-tab').click()
+
+    const submit = page.getByTestId('form-submit')
+
+    await expect(submit).toBeEnabled()
+    await submit.click()
+
+    // should still create a traditional route
+    await page.locator('.kong-ui-entities-routes-list').isVisible()
+    const trad2 = page.locator('.kong-ui-entities-routes-list table tr[data-testid="trad-2"]')
+
+    await trad2.isVisible()
+    await expect(trad2.getByTestId('paths')).toContainText('/trad/2')
+  })
+
+  test('create an expressions route - also entered traditional', async ({ page }) => {
+    await page.getByTestId('form-content').isVisible()
+
+    await page.getByTestId('route-form-name').fill('expr-2')
+
+    // switch to the expressions tab
+    await page.locator('#expressions-tab').click()
+
+    const editor = page.locator('.monaco-editor').first()
+
+    // type a valid expression
+    await editor.click()
+    await page.keyboard.type('http.path == "/expr/2"')
+
+    // switch back to the traditional tab
+    await page.locator('#traditional-tab').click()
+
+    await page.getByTestId('route-form-paths-input-1').fill('/expr/2')
+
+    // switch to the expressions tab
+    await page.locator('#expressions-tab').click()
+
+    const submit = page.getByTestId('form-submit')
+
+    await expect(submit).toBeEnabled()
+    await submit.click()
+
+    // should still create an expression route
+    await page.locator('.kong-ui-entities-routes-list').isVisible()
+    const expr2 = page.locator('.kong-ui-entities-routes-list table tr[data-testid="expr-2"]')
+
+    await expr2.isVisible()
+    await expect(expr2.getByTestId('expression')).toContainText('http.path == "/expr/2"')
+  })
+
+  test('create an expressions route - negative', async ({ page }) => {
+    await page.getByTestId('form-content').isVisible()
+
+    await page.getByTestId('route-form-name').fill('expr-3')
+
+    // switch to the expressions tab
+    await page.locator('#expressions-tab').click()
+
+    const editor = page.locator('.monaco-editor').first()
+
+    // type an invalid expression
+    await editor.click()
+    await page.keyboard.type('http.path == "/expr/3')
+
+    // the editor shows invalid
+    await expect(page.locator('.expression-editor')).toHaveClass(/invalid/)
+
+    const submit = page.getByTestId('form-submit')
+
+    // we can still submit
+    await expect(submit).toBeEnabled()
+    await submit.click()
+
+    // but it will fail
+    await page.getByTestId('form-error').isVisible()
+  })
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,7 @@ import path from 'path'
 import autoprefixer from 'autoprefixer'
 import { createHtmlPlugin } from 'vite-plugin-html'
 import { visualizer } from 'rollup-plugin-visualizer'
+import monacoEditorPlugin from 'vite-plugin-monaco-editor'
 
 const basePath = process.env.NODE_ENV !== 'production' || process.env.DISABLE_BASE_PATH === 'true' ? '/' : '/__km_base__/'
 
@@ -31,6 +32,11 @@ export default defineConfig({
           basePath,
         },
       },
+    }),
+    // See: https://github.com/vdesjs/vite-plugin-monaco-editor/issues/21
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ((monacoEditorPlugin as any).default as typeof monacoEditorPlugin)({
+      languageWorkers: ['editorWorkerService'],
     }),
     visualizer({
       filename: path.resolve(__dirname, 'bundle-analyzer/stats-treemap.html'),

--- a/yarn.lock
+++ b/yarn.lock
@@ -423,7 +423,7 @@
     "@kong/icons" "^1.9.1"
     marked "^12.0.1"
 
-"@kong-ui-public/entities-routes@^3.0.0", "@kong-ui-public/entities-routes@^3.1.5":
+"@kong-ui-public/entities-routes@^3.1.5":
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/@kong-ui-public/entities-routes/-/entities-routes-3.1.5.tgz#1d335025bc88d352b8b729d7ec26d6886c4515d9"
   integrity sha512-6cH3hUnqmM5wN35lDgtvwsyT1qyDBSI683N1+ktL2ZzBlQPUCtg6Y4XUUwLTK90jMyufVqFrcrr+LyBYgIyi5Q==
@@ -435,7 +435,7 @@
     "@kong-ui-public/expressions" "^0.2.1"
     monaco-editor "0.21.3"
 
-"@kong-ui-public/entities-shared@^3.0.0", "@kong-ui-public/entities-shared@^3.1.1":
+"@kong-ui-public/entities-shared@^3.1.1":
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/@kong-ui-public/entities-shared/-/entities-shared-3.1.1.tgz#a33ef11b884bc76218284f599e397e0478ef9a05"
   integrity sha512-YzfMAcXpSD+Eiix9NnUmJQBEJHm/7DTD2v2sOacKbrg00gK4dGgcWcB86FA5b6xi9IkhB3pVFFEO/uykZ/e70Q==
@@ -509,7 +509,12 @@
   resolved "https://registry.yarnpkg.com/@kong/design-tokens/-/design-tokens-1.12.11.tgz#4d491e198a8401252966abba0cc6185025e7c4c0"
   integrity sha512-+zgR6Ti4Joj85yD/KJzE3ja6Y0khxh9vapNnkOyGtLAUnCLstkH7WfLLhM22Qi7K5q/J2R1kWuR3X+XMp6U2mQ==
 
-"@kong/icons@^1.8.8", "@kong/icons@^1.9.0", "@kong/icons@^1.9.1":
+"@kong/icons@^1.8.8", "@kong/icons@^1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@kong/icons/-/icons-1.9.0.tgz#40391a01ccd95ff2053c962fb5e88d616bb90640"
+  integrity sha512-fA3gXZrPjhI6gV2ISV10kKG0Y6gsW+ps31ionv/09a7BY+z4K9XqNbRRzUkqZgCoTTCnf3MWYum/CRpzaYcctg==
+
+"@kong/icons@^1.9.1":
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/@kong/icons/-/icons-1.9.1.tgz#3947e3019710d306865eef19aef3ec6c89c5a5b6"
   integrity sha512-8V21s7OEXcGAWDfPlcidjLlvAemz1KxgkpNSCWC9BCMGnmYRV/1hF7hzC0Dbjz6Q5uP3jnukI+e2bkKKrxANMQ==
@@ -4439,6 +4444,11 @@ vite-plugin-html@^3.2.0:
     html-minifier-terser "^6.1.0"
     node-html-parser "^5.3.3"
     pathe "^0.2.0"
+
+vite-plugin-monaco-editor@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/vite-plugin-monaco-editor/-/vite-plugin-monaco-editor-1.1.0.tgz#a6238c2e13d5e98dd54a1bc51f6f189325219de3"
+  integrity sha512-IvtUqZotrRoVqwT0PBBDIZPNraya3BxN/bfcNfnxZ5rkJiGcNtO5eAOWWSgT7zullIAEqQwxMU83yL9J5k7gww==
 
 vite@^4.3.9:
   version "4.3.9"


### PR DESCRIPTION
### Summary

- Added support for creating/editing Expressions routes
- Updated the route list to show traditional and expression columns when Kong Gateway's `router_flavor` is configured to `expressions`
- Added test cases and updated CI workflows

KM-20