### PR TITLE
fix(*): remove unused teleport target

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -10,8 +10,6 @@
     </template>
     <router-view />
     <MakeAWish />
-    <!--Empty element just for Teleport, KHCP-11277-->
-    <div id="kong-ui-app-page-header-action-button" />
   </AppLayout>
 </template>
 


### PR DESCRIPTION
### Summary

<!--- Why is this change required? What problem does it solve? -->

Previously, we needed this element to avoid a vue warning. Now with the upgraded vue, we don't need this element anymore.

Reference: https://github.com/vuejs/core/blob/main/changelogs/CHANGELOG-3.4.md#3428-2024-06-14

<img width="895" alt="image" src="https://github.com/user-attachments/assets/e520a421-3bce-4c56-bfc1-c3e689fabc35">


### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_