### PR TITLE
feat(plugin-form): hide scoped plugin's scope change

### DIFF
--- a/src/pages/plugins/Form.vue
+++ b/src/pages/plugins/Form.vue
@@ -11,6 +11,7 @@
     :config="config"
     :plugin-type="pluginType"
     :plugin-id="pluginId"
+    :hide-scope-selection="hideScopeSelection"
     @error:fetch-schema="onFetchSchemaError"
     @update="onSave"
   />
@@ -65,6 +66,8 @@ const entityScope = computed(() => {
 
   return null
 })
+
+const hideScopeSelection = computed(() => !!entityScope.value)
 
 const redirectPath = useURLFromRouteQuery('redirect')
 

--- a/tests/playwright/specs/consumers/03-ConsumerPlugins.spec.ts
+++ b/tests/playwright/specs/consumers/03-ConsumerPlugins.spec.ts
@@ -34,7 +34,6 @@ test.describe('consumer plugins', () => {
 
   test('install a plugin from the Plugins tab', async ({ page }) => {
     await withNavigation(page, async () => await clickEntityListAction(page, 'view'))
-    const uuid = await page.locator('.copy-container').innerText()
 
     await switchDetailTab(page, 'plugins')
     await withNavigation(
@@ -45,8 +44,8 @@ test.describe('consumer plugins', () => {
       page,
       async () => await page.getByTestId('datadog-card').click(),
     )
-    await expect(page.locator('.autosuggest input#consumer-id')).toBeVisible()
-    await expect(page.locator('.autosuggest input#consumer-id')).toHaveValue(new RegExp(`${mockConsumerName}\\s*-\\s*${uuid}`))
+    await page.waitForSelector('.vue-form-generator')
+    await expect(page.locator('.selection-group')).toHaveCount(0)
     await withNavigation(
       page,
       async () => await page.locator('[data-testid="form-actions"] .primary').click(),

--- a/tests/playwright/specs/plugins/01-Plugins.spec.ts
+++ b/tests/playwright/specs/plugins/01-Plugins.spec.ts
@@ -69,10 +69,6 @@ test.describe('plugins', () => {
 
     await serviceListPage.goto()
     await withNavigation(page, async () => await clickEntityListAction(page, 'view'))
-    const uuid = (await page
-      .locator('[data-testid="id-property-value"]')
-      .locator('.copy-container')
-      .innerText() ?? '').trim()
 
     await switchDetailTab(page, 'plugins')
 
@@ -86,8 +82,8 @@ test.describe('plugins', () => {
       async () => await page.getByTestId('basic-auth-card').click(),
     )
 
-    await expect(page.locator('.autosuggest input#service-id')).toBeVisible()
-    await expect(page.locator('.autosuggest input#service-id')).toHaveValue(new RegExp(`${mockServiceName}\\s*-\\s*${uuid}`))
+    await page.waitForSelector('.vue-form-generator')
+    await expect(page.locator('.selection-group')).toHaveCount(0)
 
     await expandAdvancedFields(page)
     await page.locator('#config-anonymous').type('anon')
@@ -186,10 +182,6 @@ test.describe('plugins', () => {
 
     await routeListPage.goto()
     await withNavigation(page, async () => await clickEntityListAction(page, 'view'))
-    const uuid = (await page
-      .locator('[data-testid="id-property-value"]')
-      .locator('.copy-container')
-      .innerText() ?? '').trim()
 
     await switchDetailTab(page, 'plugins')
 
@@ -203,8 +195,8 @@ test.describe('plugins', () => {
       async () => await page.getByTestId('basic-auth-card').click(),
     )
 
-    await expect(page.locator('.autosuggest input#route-id')).toBeVisible()
-    await expect(page.locator('.autosuggest input#route-id')).toHaveValue(new RegExp(`${mockRouteName}\\s*-\\s*${uuid}`))
+    await page.waitForSelector('.vue-form-generator')
+    await expect(page.locator('.selection-group')).toHaveCount(0)
 
     await withNavigation(
       page,
@@ -222,10 +214,6 @@ test.describe('plugins', () => {
     await consumerListPage.goto()
 
     await withNavigation(page, async () => await clickEntityListAction(page, 'view'))
-    const uuid = (await page
-      .locator('[data-testid="id-property-value"]')
-      .locator('.copy-container')
-      .innerText() ?? '').trim()
 
     await switchDetailTab(page, 'plugins')
     await withNavigation(
@@ -236,8 +224,8 @@ test.describe('plugins', () => {
       page,
       async () => await page.getByTestId('datadog-card').click(),
     )
-    await expect(page.locator('.autosuggest input#consumer-id')).toBeVisible()
-    await expect(page.locator('.autosuggest input#consumer-id')).toHaveValue(new RegExp(`${mockConsumerName}\\s*-\\s*${uuid}`))
+    await page.waitForSelector('.vue-form-generator')
+    await expect(page.locator('.selection-group')).toHaveCount(0)
     await withNavigation(
       page,
       async () => await page.locator('[data-testid="form-actions"] .primary').click(),

--- a/tests/playwright/specs/routes/02-RoutesPlugins.spec.ts
+++ b/tests/playwright/specs/routes/02-RoutesPlugins.spec.ts
@@ -52,11 +52,6 @@ test.describe('routes plugins', () => {
   test(`install a plugin for the route "${mockRouteName} from the plugins tab"`, async ({ page }) => {
     await withNavigation(page, async () => await clickEntityListAction(page, 'view'))
 
-    const uuid = (await page
-      .locator('[data-testid="id-property-value"]')
-      .locator('.copy-container')
-      .innerText() ?? '').trim()
-
     await switchDetailTab(page, 'plugins')
 
     await withNavigation(
@@ -69,8 +64,8 @@ test.describe('routes plugins', () => {
       async () => await page.getByTestId('basic-auth-card').click(),
     )
 
-    await expect(page.locator('.autosuggest input#route-id')).toBeVisible()
-    await expect(page.locator('.autosuggest input#route-id')).toHaveValue(new RegExp(`${mockRouteName}\\s*-\\s*${uuid}`))
+    await page.waitForSelector('.vue-form-generator')
+    await expect(page.locator('.selection-group')).toHaveCount(0)
 
     await withNavigation(
       page,


### PR DESCRIPTION
### Summary

When creating/editing a scoped plugin from plugin list under another scope, hide scoped plugin's scope change field