### PR TITLE
fix(*): add proper cache-identifier to all entity lists

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-  "recommendations": ["Vue.volar", "Vue.vscode-typescript-vue-plugin"]
+  "recommendations": ["Vue.volar"]
 }

--- a/src/pages/ca-certificates/List.vue
+++ b/src/pages/ca-certificates/List.vue
@@ -10,6 +10,7 @@
     </template>
   </PageHeader>
   <CACertificateList
+    cache-identifier="ca_certificates"
     :config="caCertificateListConfig"
     :can-create="canCreate"
     :can-delete="canDelete"

--- a/src/pages/certificates/List.vue
+++ b/src/pages/certificates/List.vue
@@ -10,6 +10,7 @@
     </template>
   </PageHeader>
   <CertificateList
+    cache-identifier="certificates"
     :config="certificateListConfig"
     :can-create="canCreate"
     :can-delete="canDelete"

--- a/src/pages/consumers/List.vue
+++ b/src/pages/consumers/List.vue
@@ -10,6 +10,7 @@
     </template>
   </PageHeader>
   <ConsumerList
+    cache-identifier="consumers"
     :config="consumerListConfig"
     :can-create="canCreate"
     :can-delete="canDelete"

--- a/src/pages/key-sets/List.vue
+++ b/src/pages/key-sets/List.vue
@@ -10,6 +10,7 @@
     </template>
   </PageHeader>
   <KeySetList
+    cache-identifier="key_sets"
     :config="keyListConfig"
     :can-create="canCreate"
     :can-delete="canDelete"

--- a/src/pages/keys/List.vue
+++ b/src/pages/keys/List.vue
@@ -49,7 +49,7 @@ const { t } = useI18n()
 const docsLink = useDocsLink(EntityType.Key)
 
 const keySetId = computed(() => (route.params?.id ?? '') as string)
-const cacheIdentifier = computed(() => `routes-${keySetId.value}`)
+const cacheIdentifier = computed(() => `keys-${keySetId.value}`)
 
 const filterSchema = computed<FilterSchema>(() => {
   return {

--- a/src/pages/services/List.vue
+++ b/src/pages/services/List.vue
@@ -10,6 +10,7 @@
     </template>
   </PageHeader>
   <GatewayServiceList
+    cache-identifier="services"
     :config="serviceListConfig"
     :can-create="canCreate"
     :can-delete="canDelete"

--- a/src/pages/snis/List.vue
+++ b/src/pages/snis/List.vue
@@ -10,6 +10,7 @@
     </template>
   </PageHeader>
   <SniList
+    cache-identifier="snis"
     :config="sniListConfig"
     :can-create="canCreate"
     :can-delete="canDelete"

--- a/src/pages/upstreams/List.vue
+++ b/src/pages/upstreams/List.vue
@@ -10,6 +10,7 @@
     </template>
   </PageHeader>
   <UpstreamsList
+    cache-identifier="upstreams"
     :config="upstreamListConfig"
     :can-create="canCreate"
     :can-delete="canDelete"

--- a/src/pages/vaults/List.vue
+++ b/src/pages/vaults/List.vue
@@ -10,6 +10,7 @@
     </template>
   </PageHeader>
   <VaultList
+    cache-identifier="vaults"
     :config="vaultListConfig"
     :can-create="canCreate"
     :can-delete="canDelete"


### PR DESCRIPTION
### Summary

KM-770

Add proper `cache-identifier` to entity lists.