### PR TITLE
chore(*): backport trigger

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,7 +1,7 @@
 name: Backport
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - closed
       - labeled


### PR DESCRIPTION
### Summary

<!--- Why is this change required? What problem does it solve? -->

Replacing `pull_request_target` with `pull_request` for security concerns.

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->
Fix #_[issue number]_