### PR TITLE
chore: remove auth rule in npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-//registry.npmjs.org/:_authToken=${NPM_TOKEN}


### PR DESCRIPTION
### Summary

Fix the warning in checking dependabot.yml
```
The property '#/registries/npm/' of type object did not match one or more of the required schemas
```