### PR TITLE
chore(ci): Using image from kong-dev due to security

### DIFF
--- a/.github/actions/select-gateway-image/action.yml
+++ b/.github/actions/select-gateway-image/action.yml
@@ -16,7 +16,7 @@ runs:
       id: select-image
       shell: bash
       env:
-        DEFAULT_GATEWAY_IMAGE: kong/kong:master-ubuntu
+        DEFAULT_GATEWAY_IMAGE: kong/kong-dev:master-ubuntu
       run: |
         GATEWAY_IMAGE="${{ inputs.current-image }}"
 


### PR DESCRIPTION
Use images from kong-dev, generated by PRs and nightly build

### Summary

Use docker image from kong-dev, generated by PRs and nightly build.

### Issue reference

KM-984
