### PR TITLE
chore(ci): bring release steps back

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ on:
     branches: ["main"]
     # [NOTE] tags
     # On main branch: nightly
-    # On release branch: vX.X.*
+    # On release branch: vX.X.**
     tags: ["nightly"]
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,6 +54,8 @@ jobs:
     name: Create Release
     needs: [e2e-tests, e2e-tests-csp-on]
     runs-on: ${{ vars.RUNS_ON }}
+    permissions:
+      contents: write
     steps:
       - name: Download release
         timeout-minutes: 5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,8 +7,8 @@ concurrency:
 on:
   pull_request:
   push:
-    branches:
-      - '!release/*'
+    branches-ignore:
+      - 'release/**'
     tags:
       - 'nightly'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,6 @@ on:
   pull_request:
   push:
     branches:
-      - '*'
       - '!release/*'
     tags:
       - 'nightly'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,8 @@ jobs:
       github.event_name == 'push' && (
         github.ref == 'refs/heads/main' ||
         startsWith(github.ref, 'refs/heads/release/') ||
-        startsWith(github.ref, 'refs/tags/')
+        startsWith(github.ref, 'refs/tags/') ||
+        github.ref == 'refs/heads/chore/ci-release'
       )
     name: Create Release
     needs: [e2e-tests, e2e-tests-csp-on]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,36 +67,36 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPOSITORY: ${{ github.repository }}
-          RELEASE_TAG_NAME: nightly
+          RELEASE_TAG_NAME: test-nightly
           RELEASE_TARGET: ${{ github.sha }}
         run: |
-          # previous=$(
-          #   gh release view $RELEASE_TAG_NAME -R $GH_REPOSITORY >/dev/null 2>&1
-          #   if [[ $? == 0 ]]; then
-          #     echo true
-          #   else
-          #     echo false
-          #   fi
-          # )
+          previous=$(
+            gh release view $RELEASE_TAG_NAME -R $GH_REPOSITORY >/dev/null 2>&1
+            if [[ $? == 0 ]]; then
+              echo true
+            else
+              echo false
+            fi
+          )
 
-          # if $previous; then
-          #   echo "Deleting the existing release..."
-          #   gh release delete $RELEASE_TAG_NAME -R $GH_REPOSITORY --cleanup-tag -y
-          # else
-          #   echo "No previous release found"
-          # fi
+          if $previous; then
+            echo "Deleting the existing release..."
+            gh release delete $RELEASE_TAG_NAME -R $GH_REPOSITORY --cleanup-tag -y
+          else
+            echo "No previous release found"
+          fi
 
-          # echo "Deleting the associated tag..."
-          # gh api \
-          #   --method DELETE \
-          #   -H "Accept: application/vnd.github+json" \
-          #   -H "X-GitHub-Api-Version: 2022-11-28" \
-          #   /repos/$GH_REPOSITORY/git/refs/tags/$RELEASE_TAG_NAME >/dev/null 2>&1 || true
+          echo "Deleting the associated tag..."
+          gh api \
+            --method DELETE \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/$GH_REPOSITORY/git/refs/tags/$RELEASE_TAG_NAME >/dev/null 2>&1 || true
 
-          # echo "Creating a new release with assets..."
-          # gh release create $RELEASE_TAG_NAME -t $RELEASE_TAG_NAME --target $RELEASE_TARGET -R $GH_REPOSITORY release.tar.gz
+          echo "Creating a new release with assets..."
+          gh release create $RELEASE_TAG_NAME -t $RELEASE_TAG_NAME --target $RELEASE_TARGET -R $GH_REPOSITORY release.tar.gz
 
-      - name: Create non-nightly release
+      - name: Create non-nightly (tagged) release
         if: startsWith(github.ref, 'refs/tags/')
         shell: bash
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,11 +7,11 @@ concurrency:
 on:
   pull_request:
   push:
-    # [NOTE] Branches
+    # [NOTE] branches
     # On main branch: main
     # On release branch: release/**
     branches: ["main"]
-    # [NOTE] Tags
+    # [NOTE] tags
     # On main branch: nightly
     # On release branch: vX.X.*
     tags: ["nightly"]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,10 +7,14 @@ concurrency:
 on:
   pull_request:
   push:
-    branches-ignore:
-      - 'release/**'
-    tags:
-      - 'nightly'
+    # [NOTE] Branches
+    # On main branch: main
+    # On release branch: release/**
+    branches: ["main"]
+    # [NOTE] Tags
+    # On main branch: nightly
+    # On release branch: vX.X.*
+    tags: ["nightly"]
 
 jobs:
   build:
@@ -42,14 +46,13 @@ jobs:
       gateway-image: ${{ needs.build-test-image.outputs.image }}
       load-test-image-from-artifact: true
       enable-csp-header: true
-  
+
   create-release:
     if: >-
       github.event_name == 'push' && (
         github.ref == 'refs/heads/main' ||
         startsWith(github.ref, 'refs/heads/release/') ||
-        startsWith(github.ref, 'refs/tags/') ||
-        github.ref == 'refs/heads/chore/ci-release'
+        startsWith(github.ref, 'refs/tags/')
       )
     name: Create Release
     needs: [e2e-tests, e2e-tests-csp-on]
@@ -62,14 +65,17 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: release
-      
+
       - name: Create nightly release
-        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') || github.ref == 'refs/heads/chore/ci-release'
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')'
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPOSITORY: ${{ github.repository }}
-          RELEASE_TAG_NAME: test-nightly
+          # [NOTE] RELEASE_TAG_NAME
+          # On main branch: nightly
+          # On release branch: vX.X-nightly
+          RELEASE_TAG_NAME: nightly
           RELEASE_TARGET: ${{ github.sha }}
         run: |
           previous=$(
@@ -107,21 +113,21 @@ jobs:
           RELEASE_TAG_NAME: ${{ github.ref_name }} # this is the tag name
           RELEASE_TARGET: ${{ github.sha }}
         run: |
-          # previous=$(
-          #   gh release view $RELEASE_TAG_NAME -R $GH_REPOSITORY >/dev/null 2>&1
-          #   if [[ $? == 0 ]]; then
-          #     echo true
-          #   else
-          #     echo false
-          #   fi
-          # )
+          previous=$(
+            gh release view $RELEASE_TAG_NAME -R $GH_REPOSITORY >/dev/null 2>&1
+            if [[ $? == 0 ]]; then
+              echo true
+            else
+              echo false
+            fi
+          )
 
-          # if $previous; then
-          #   echo "Release already exists"
-          #   echo "Replacing assets..."
-          #   gh release upload $RELEASE_TAG_NAME release.tar.gz --clobber -R $GH_REPOSITORY
-          # else
-          #   echo "No previous release found"
-          #   echo "Creating a new release with assets..."
-          #   gh release create $RELEASE_TAG_NAME -t $RELEASE_TAG_NAME --target $RELEASE_TARGET -R $GH_REPOSITORY release.tar.gz
-          # fi
+          if $previous; then
+            echo "Release already exists"
+            echo "Replacing assets..."
+            gh release upload $RELEASE_TAG_NAME release.tar.gz --clobber -R $GH_REPOSITORY
+          else
+            echo "No previous release found"
+            echo "Creating a new release with assets..."
+            gh release create $RELEASE_TAG_NAME -t $RELEASE_TAG_NAME --target $RELEASE_TARGET -R $GH_REPOSITORY release.tar.gz
+          fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,9 +8,10 @@ on:
   pull_request:
   push:
     branches:
-      - main
-    tags:
       - '*'
+      - '!release/*'
+    tags:
+      - 'nightly'
 
 jobs:
   build:
@@ -42,3 +43,83 @@ jobs:
       gateway-image: ${{ needs.build-test-image.outputs.image }}
       load-test-image-from-artifact: true
       enable-csp-header: true
+  
+  create-release:
+    if: >-
+      github.event_name == 'push' && (
+        github.ref == 'refs/heads/main' ||
+        startsWith(github.ref, 'refs/heads/release/') ||
+        startsWith(github.ref, 'refs/tags/')
+      )
+    name: Create Release
+    needs: [e2e-tests, e2e-tests-csp-on]
+    runs-on: ${{ vars.RUNS_ON }}
+    steps:
+      - name: Download release
+        timeout-minutes: 5
+        uses: actions/download-artifact@v4
+        with:
+          name: release
+      
+      - name: Create nightly release
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') || github.ref == 'refs/heads/chore/ci-release'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPOSITORY: ${{ github.repository }}
+          RELEASE_TAG_NAME: nightly
+          RELEASE_TARGET: ${{ github.sha }}
+        run: |
+          # previous=$(
+          #   gh release view $RELEASE_TAG_NAME -R $GH_REPOSITORY >/dev/null 2>&1
+          #   if [[ $? == 0 ]]; then
+          #     echo true
+          #   else
+          #     echo false
+          #   fi
+          # )
+
+          # if $previous; then
+          #   echo "Deleting the existing release..."
+          #   gh release delete $RELEASE_TAG_NAME -R $GH_REPOSITORY --cleanup-tag -y
+          # else
+          #   echo "No previous release found"
+          # fi
+
+          # echo "Deleting the associated tag..."
+          # gh api \
+          #   --method DELETE \
+          #   -H "Accept: application/vnd.github+json" \
+          #   -H "X-GitHub-Api-Version: 2022-11-28" \
+          #   /repos/$GH_REPOSITORY/git/refs/tags/$RELEASE_TAG_NAME >/dev/null 2>&1 || true
+
+          # echo "Creating a new release with assets..."
+          # gh release create $RELEASE_TAG_NAME -t $RELEASE_TAG_NAME --target $RELEASE_TARGET -R $GH_REPOSITORY release.tar.gz
+
+      - name: Create non-nightly release
+        if: startsWith(github.ref, 'refs/tags/')
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPOSITORY: ${{ github.repository }}
+          RELEASE_TAG_NAME: ${{ github.ref_name }} # this is the tag name
+          RELEASE_TARGET: ${{ github.sha }}
+        run: |
+          # previous=$(
+          #   gh release view $RELEASE_TAG_NAME -R $GH_REPOSITORY >/dev/null 2>&1
+          #   if [[ $? == 0 ]]; then
+          #     echo true
+          #   else
+          #     echo false
+          #   fi
+          # )
+
+          # if $previous; then
+          #   echo "Release already exists"
+          #   echo "Replacing assets..."
+          #   gh release upload $RELEASE_TAG_NAME release.tar.gz --clobber -R $GH_REPOSITORY
+          # else
+          #   echo "No previous release found"
+          #   echo "Creating a new release with assets..."
+          #   gh release create $RELEASE_TAG_NAME -t $RELEASE_TAG_NAME --target $RELEASE_TARGET -R $GH_REPOSITORY release.tar.gz
+          # fi


### PR DESCRIPTION
This PR brings back the nightly/non-nightly (tagged) release workflow steps to this repo.

This PR is only fit for the `main` branch. When backporting, changes must follow the comments with `[NOTE]` to trigger the changes 

Example run: https://github.com/Kong/kong-manager/actions/runs/17712102976/job/50332280193