### PR TITLE
chore(renovate): pin @kong-ui-public/entities-plugins to v9.x

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -43,6 +43,16 @@
       ]
     },
     {
+      "description": "Pin @kong-ui-public/entities-plugins to v9.x, never allow major version bumps",
+      "matchPackageNames": [
+        "@kong-ui-public/entities-plugins"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "enabled": false
+    },
+    {
       "description": "playwright, axios, lodash - enable",
       "enabled": true,
       "matchPackageNames": [


### PR DESCRIPTION
## Summary
- Add a Renovate packageRule that disables major-version updates for `@kong-ui-public/entities-plugins`, keeping it locked to the 9.x line
- Minor/patch updates for this package continue to flow through the existing "kong packages" group; other `@kong/*` and `@kong-ui-public/*` packages are unaffected

